### PR TITLE
feat: disable hash verification for git-objects

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,8 @@ async fn main() -> Result<()> {
         repo: ref repos,
     } = Config::from_file(opt.config)?;
 
+    git2::opts::strict_hash_verification(false);
+
     for repo in repos {
         info!("scan {}/{}", repo.name, repo.branch);
         do_scan_and_update(global, repo).await?;


### PR DESCRIPTION
https://docs.rs/git2/latest/git2/opts/fn.strict_hash_verification.html

> Controls whether or not libgit2 will verify that objects loaded have the expected hash. Enabled by default, but disabling this can **significantly** improve performance, at the cost of relying on repository integrity without checking it.

In 95% of cases, there's no need to care about this option, and it's recommended to turn it off.